### PR TITLE
Fix path issue for windows machines

### DIFF
--- a/R/GetData.R
+++ b/R/GetData.R
@@ -1,3 +1,19 @@
+#' Return normalized path for all operating systems
+#'
+#' @param ReferencePath a path to join with current working directory
+#' @param BasePath Current working directory else path given
+#'
+#' @return
+#' @export
+#' @examples
+#' FullPath('PortalData/Rodents/Portal_rodent.csv')
+#' FullPath('PortalData/Rodents/Portal_rodent.csv', '~')
+FullPath <- function( ReferencePath, BasePath=getwd()){
+  BasePath = normalizePath(BasePath)
+  Path = normalizePath(file.path(BasePath, ReferencePath), mustWork = FALSE)
+  return (Path)
+}
+
 #' Download the PortalData repo
 #' 
 #' This downloads the latest portal data regardless if they are
@@ -5,28 +21,26 @@
 #' 
 #' TODO: incorperate data retriever into this when it's pointed at the github repo
 #' @return None
-download_observations = function(base_folder='~/'){
-  base_folder=path.expand(base_folder)
+download_observations = function(base_folder='~'){
   zip_download_path='https://github.com/weecology/PortalData/archive/master.zip'
-  zip_download_dest=file.path(base_folder,'PortalData.zip')
+  zip_download_dest=FullPath('PortalData.zip', base_folder)
   download.file(zip_download_path, zip_download_dest, quiet = TRUE)
   
-  final_data_folder=file.path(base_folder,'PortalData')
+  final_data_folder=FullPath('PortalData', base_folder)
   
   #Clear out the old files in the data folder without doing potentially dangerous
   #recursive deleting.
   if(file.exists(final_data_folder)) {
     old_files=list.files(final_data_folder, full.names = TRUE, all.files = TRUE, recursive = TRUE, include.dirs = FALSE)
-    file.remove(old_files)
-    old_dirs=list.files(final_data_folder, full.names = TRUE, recursive = TRUE, include.dirs = TRUE)
-    file.remove(old_dirs)
+    file.remove(normalizePath(old_files))
+    unlink(final_data_folder, recursive=TRUE)
   }
   
   #Github serves this up with the -master extension. Unzip and rename to remove that. 
   unzip(zip_download_dest, exdir=base_folder)
   Sys.sleep(10)
   file.remove(zip_download_dest)
-  file.rename(file.path(base_folder,'PortalData-master'), final_data_folder)
+  file.rename(FullPath('PortalData-master', base_folder), final_data_folder)
 }
 
 #' Check if there are new rodent observations. This only checks the
@@ -34,10 +48,9 @@ download_observations = function(base_folder='~/'){
 #' will not show that there is new data available.
 #' 
 #' @return bool True if new observations are available
-observations_are_new = function(base_folder='~/'){
-  base_folder=path.expand(base_folder)
+observations_are_new = function(base_folder='~'){
   md5_file = './Portal_rodent.md5'
-  rodent_file= path.expand(paste0(base_folder,'PortalData/Rodents/Portal_rodent.csv'))
+  rodent_file= FullPath('PortalData/Rodents/Portal_rodent.csv', base_folder)
   if(!file.exists(rodent_file)) stop('Rodent observations not present. Please run download_observations()')
   
   if(!file.exists(md5_file)) {


### PR DESCRIPTION
Uses the function FullPath() created by Henry and Erica over in the portalPredictions repo to fix download_observations so that a base_folder='~' works on windows machines.

Fixes issue #33 